### PR TITLE
Issue #3: Fix acorn parsing error for modules

### DIFF
--- a/lib/find-jsx-node.js
+++ b/lib/find-jsx-node.js
@@ -14,7 +14,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 var extendedAcornParser = _acorn.Parser.extend((0, _acornJsx["default"])());
 
 var findJSXNode = function findJSXNode(walker, content) {
-  var root = extendedAcornParser.parse(content);
+  var root = extendedAcornParser.parse(content, { allowImportExportEverywhere: true });
   var foundNode = null;
   walker.simple(root, {
     JSXElement: function JSXElement(node) {

--- a/src/find-jsx-node.js
+++ b/src/find-jsx-node.js
@@ -4,7 +4,7 @@ import acornJSX from 'acorn-jsx';
 const extendedAcornParser = Parser.extend(acornJSX());
 
 const findJSXNode = (walker, content) => {
-  const root = extendedAcornParser.parse(content);
+  const root = extendedAcornParser.parse(content, { allowImportExportEverywhere: true });
 
   let foundNode = null;
 


### PR DESCRIPTION
Acorn expects the value "module" on the `sourceType` prop to parse modules otherwise it throws an error when bundling with webpack.

But "jsx-vanilla" doesn't define any options while initiating the parser thus `sourceType` prop defaults to "script" and throws an error when you're using a module with webpack or a different bundler.

 And this commit takes care of that problem by overriding the rule by setting the parser option `allowImportExportEverywhere` to true when initiating the parser.
 
 Related issue:
 
 https://github.com/AdeonMaster/jsx-vanilla/issues/3#issue-904626694
 
 Discussions about this problem:
 
 https://github.com/acornjs/acorn/issues/241
 https://github.com/acornjs/acorn/issues/343#issuecomment-151875817